### PR TITLE
Proposed change: use core/event-handler for control stage

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,4 +1,4 @@
-local handler = require "__core__/lualib/event_handler"
+local handler = require "__core__.lualib.event_handler"
 
 ---@class ScriptLib
 ---@field add_commands? fun()
@@ -25,7 +25,7 @@ handler.add_libraries{
 
 local scanner_filter = {{filter = "name", name = "ff-seismic-scanner"}}
 
-script.set_event_filter(defines.events.on_sector_scanned     --[[@as uint]], scanner_filter)
+script.set_event_filter(defines.events.on_built_entity       --[[@as uint]], scanner_filter)
 script.set_event_filter(defines.events.on_robot_built_entity --[[@as uint]], scanner_filter)
 script.set_event_filter(defines.events.on_sector_scanned     --[[@as uint]], scanner_filter)
 

--- a/scripts/burnt-result.lua
+++ b/scripts/burnt-result.lua
@@ -1,0 +1,27 @@
+-- Recover empty batteries when mining discharging station
+local function recover_burnt_result(event)
+  local entity = event.entity
+  local buffer = event.buffer
+  if entity and buffer then
+    local burner = entity.burner
+    if burner then
+      local burning = burner.currently_burning
+      if burning then
+        local burnt_result = burning.burnt_result
+        if burnt_result then
+          event.buffer.insert{name=burnt_result.name,count=1}
+        end
+      end
+    end
+  end
+end
+
+---@type ScriptLib
+local BurntResult = {}
+
+BurntResult.events = {
+  [defines.events.on_player_mined_entity] = recover_burnt_result,
+  [defines.events.on_robot_mined_entity]  = recover_burnt_result,
+}
+
+return BurntResult

--- a/scripts/collision-test.lua
+++ b/scripts/collision-test.lua
@@ -1,5 +1,3 @@
-local CollisionTest = {}
-
 -- tile, entity, should_collide
 local test_cases = {
   {"water", "character", true},
@@ -53,7 +51,7 @@ local test_cases = {
 
 }
 
-function CollisionTest.run()
+local function run_test()
   local tiles = game.tile_prototypes
   local entities = game.entity_prototypes
   local tests_failed = 0
@@ -80,5 +78,11 @@ function CollisionTest.run()
   end
   log("CollisionTest finished: " .. tests_passed .. " tests passed, " .. tests_failed .. " tests failed.")
 end
+
+---@type ScriptLib
+local CollisionTest = {}
+
+CollisionTest.on_init = run_test
+CollisionTest.on_configuration_changed = run_test
 
 return CollisionTest

--- a/scripts/compatibility.lua
+++ b/scripts/compatibility.lua
@@ -3,11 +3,11 @@ local milestones    = require "compatibility.milestones.control"
 
 local Compatibility = {}
 
-function Compatibility.load()
+Compatibility.on_load = function()
   milestones.load()
 end
 
-function Compatibility.init()
+Compatibility.on_init = function()
   disco_science.init()
 end
 

--- a/scripts/dredging-platform.lua
+++ b/scripts/dredging-platform.lua
@@ -6,7 +6,10 @@ local function add_square(x, y, tiles)
   end
 end
 
-function dredger_created(dredger)
+local function on_dredger_created(event)
+  if event.effect_id ~= "ff-dredger-created" then return end
+  
+  local dredger = event.target_entity
   local force = dredger.force
   local surface = dredger.surface
   local position = dredger.position
@@ -55,3 +58,12 @@ function dredger_created(dredger)
 
   surface.set_tiles(tiles, true, false)
 end
+
+---@type ScriptLib
+local DredgingPlatform = {}
+
+DredgingPlatform.events = {
+  [defines.events.on_script_trigger_effect] = on_dredger_created
+}
+
+return DredgingPlatform

--- a/scripts/endgame.lua
+++ b/scripts/endgame.lua
@@ -1,6 +1,10 @@
-if script.active_mods["Krastorio2"] or script.active_mods["SpaceMod"] then return end
+local function interfering_mods()
+  return script.active_mods["Krastorio2"] or script.active_mods["SpaceMod"]
+end
 
-script.on_event(defines.events.on_rocket_launched, function(event)
+local function on_rocket_launched(event)
+  if interfering_mods() then return end
+
   local rocket = event.rocket
   if not (rocket and rocket.valid) then return end
   
@@ -15,4 +19,27 @@ script.on_event(defines.events.on_rocket_launched, function(event)
       victorious_force = rocket.force
     }
   end
-end)
+end
+
+local function disable_rocket_vistory()
+  if interfering_mods() then return end
+  
+  if remote.interfaces["silo_script"] and remote.interfaces["silo_script"]["set_no_victory"] then
+    remote.call("silo_script", "set_no_victory", true)
+  end
+  if remote.interfaces["freeplay"] and remote.interfaces["freeplay"]["set_custom_intro_message"] then
+    remote.call("freeplay", "set_custom_intro_message", {"freight-forwarding.msg-intro"})
+  end
+end
+
+---@type ScriptLib
+local Endgame = {}
+
+Endgame.events = {
+  [defines.events.on_rocket_launched] = on_rocket_launched
+}
+
+Endgame.on_init = disable_rocket_vistory
+Endgame.on_configuration_changed = disable_rocket_vistory
+
+return Endgame

--- a/scripts/landfill-hidden-tile.lua
+++ b/scripts/landfill-hidden-tile.lua
@@ -21,7 +21,6 @@ local function set_landfill_hidden_tile(x, y, tile)
 	table.insert(global.landfill, data)
 end
 
-
 local function get_landfill_hidden_tile(x, y)
 	if global.landfill == nil then
 		game.print("error failed to get tile below landfill. using default")
@@ -37,7 +36,6 @@ local function get_landfill_hidden_tile(x, y)
 	game.print("error failed to get tile below landfill. using default")
 	return "water"
 end
-
 
 local function save_landfill_hidden_tile(event)
 	--game.print("restore_landfill_hidden_tile")
@@ -57,7 +55,6 @@ local function save_landfill_hidden_tile(event)
 	return landfill_count
 end
 
-
 local function on_player_built_tile(event)
 	--game.print("on_player_built_tile")
 	local landfill_count = save_landfill_hidden_tile(event)
@@ -66,10 +63,11 @@ local function on_player_built_tile(event)
 		--game.print("steal player "..landfill_count.." landfill")
 		local player = game.players[event.player_index]
 		local inventory = player.get_inventory(defines.inventory.character_main)
-		inventory.remove({name="landfill", count=landfill_count})
+		if inventory then 
+			inventory.remove({name="landfill", count=landfill_count})
+		end
 	end
 end
-
 
 local function on_robot_built_tile(event)
 	--game.print("on_robot_built_tile")
@@ -81,7 +79,6 @@ local function on_robot_built_tile(event)
 		inventory.remove({name="landfill", count=landfill_count})
 	end
 end
-
 
 local function on_mined_tile(event)
 	--game.print("on_mined_tile")
@@ -98,8 +95,14 @@ local function on_mined_tile(event)
 	end
 end
 
+---@type ScriptLib
+local Landfill = {}
 
-script.on_event(defines.events.on_player_built_tile, on_player_built_tile)
-script.on_event(defines.events.on_robot_built_tile, on_robot_built_tile)
-script.on_event(defines.events.on_player_mined_tile, on_mined_tile)
-script.on_event(defines.events.on_robot_mined_tile, on_mined_tile)
+Landfill.events = {
+	[defines.events.on_player_built_tile] = on_player_built_tile,
+	[defines.events.on_player_mined_tile] = on_mined_tile,
+	[defines.events.on_robot_built_tile] 	= on_robot_built_tile,
+	[defines.events.on_robot_mined_tile] 	= on_mined_tile,
+}
+
+return Landfill

--- a/scripts/landfill-hidden-tile.lua
+++ b/scripts/landfill-hidden-tile.lua
@@ -99,10 +99,10 @@ end
 local Landfill = {}
 
 Landfill.events = {
-	[defines.events.on_player_built_tile] = on_player_built_tile,
-	[defines.events.on_player_mined_tile] = on_mined_tile,
-	[defines.events.on_robot_built_tile] 	= on_robot_built_tile,
-	[defines.events.on_robot_mined_tile] 	= on_mined_tile,
+	[defines.events.on_player_built_tile]	= on_player_built_tile,
+	[defines.events.on_player_mined_tile]	= on_mined_tile,
+	[defines.events.on_robot_built_tile]	= on_robot_built_tile,
+	[defines.events.on_robot_mined_tile]	= on_mined_tile,
 }
 
 return Landfill

--- a/scripts/lava-pool.lua
+++ b/scripts/lava-pool.lua
@@ -1,0 +1,49 @@
+local function on_lava_pool_created(event)
+  if event.effect_id ~= "ff-lava-pool-created" then return end
+  local lava_pool = event.target_entity
+  lava_pool.amount = 1
+  local surface = lava_pool.surface
+  local position = lava_pool.position
+  local created = false
+  if math.random() > 0.4 then
+    if surface.can_place_entity{name = "ff-lava-pool", position = position, force = "player"} then
+      created = surface.create_entity{name = "ff-lava-pool", position = position, force = "player", false}
+    end
+  end
+  if not created then
+    if surface.can_place_entity{name = "ff-lava-pool-small", position = position, force = "player"} then
+      created = surface.create_entity{name = "ff-lava-pool-small", position = position, force = "player", false}
+    end
+  end
+  if created then
+    created.destructible = false
+  else
+    --game.print("Lava pool destroyed!")
+    lava_pool.destroy()
+  end
+end
+
+---@type ScriptLib
+local LavaPool = {}
+
+LavaPool.events = {
+  [defines.events.on_script_trigger_effect] = on_lava_pool_created
+}
+
+LavaPool.on_init = function()
+  for _, surface in pairs(game.surfaces) do
+    for _, entity in pairs(surface.find_entities_filtered{type = "resource", name = "ff-lava-pool-resource", force = "neutral"}) do
+      on_lava_pool_created({ event_id = "ff-lava-pool-created", target_entity = entity })
+    end
+  end
+end
+
+LavaPool.on_configuration_changed = function()
+  for _, surface in pairs(game.surfaces) do
+    for _, entity in pairs(surface.find_entities_filtered{type = "assembling-machine", name = {"ff-lava-pool", "ff-lava-pool-small"}, force = "player"}) do
+      entity.destructible = false
+    end
+  end
+end
+
+return LavaPool

--- a/scripts/migrations.lua
+++ b/scripts/migrations.lua
@@ -1,0 +1,32 @@
+require "util"
+
+---@type ScriptLib
+local Migrations = {}
+
+Migrations.on_configuration_changed = function(changed_data)
+  for _, force in pairs(game.forces) do
+    force.reset_technology_effects()
+  end
+  
+  local old_version
+  local mod_changes = changed_data.mod_changes
+  if mod_changes and mod_changes["FreightForwarding"] and mod_changes["FreightForwarding"]["old_version"] then
+    old_version = mod_changes["FreightForwarding"]["old_version"]
+  else
+    return
+  end
+
+  old_version = util.split(old_version, ".")
+  if tonumber(old_version[1]) == 1 then
+    if tonumber(old_version[2]) <= 5 then
+      -- Run on 1.5.0 load
+      for _, force in pairs(game.forces) do
+        if force.technologies["railway"].researched then
+          force.print("[Freight Forwarding] This update changes trains to use batteries rather than burnable fuel. If you wish to revert this behaviour so that your existing factory continues to run, you can do so from [font=default-large-semibold]Main Menu > Settings > Mod settings > Startup[/font]")
+        end
+      end
+    end
+  end
+end
+
+return Migrations

--- a/scripts/seamount.lua
+++ b/scripts/seamount.lua
@@ -1,0 +1,28 @@
+local function on_seamount_created(event)
+  if event.effect_id ~= "ff-seamount-created" then return end
+  
+  local seamount = event.target_entity
+  seamount.amount = 1
+
+  -- Resources are created centered on a tile, we need to change that, and teleport it to a 2x2-tile position
+  local position = seamount.position
+  local x = math.floor(position.x)
+  local y = math.floor(position.y)
+  if x % 2 == 1 then
+    x = x + 1
+  end
+  if y % 2 == 1 then
+    y = y + 1
+  end
+  seamount.teleport{x = x, y = y}
+end
+
+---@type ScriptLib
+local Seamount = {}
+
+Seamount.events = {
+  [defines.events.on_script_trigger_effect] = on_seamount_created
+}
+
+return Seamount
+

--- a/scripts/seismic-scanning.lua
+++ b/scripts/seismic-scanning.lua
@@ -89,8 +89,6 @@ local function on_sector_scanned(event)
   end
 end
 
-script.on_event(defines.events.on_sector_scanned, on_sector_scanned, {{filter = "name", name = "ff-seismic-scanner"}})
-
 local function on_scanner_built(event)
   -- Disable scanner if within 16 tiles of water
   local scanner = event.created_entity
@@ -105,5 +103,13 @@ local function on_scanner_built(event)
   end
 end
 
-script.on_event(defines.events.on_built_entity, on_scanner_built, {{filter = "name", name = "ff-seismic-scanner"}})
-script.on_event(defines.events.on_robot_built_entity, on_scanner_built, {{filter = "name", name = "ff-seismic-scanner"}})
+---@type ScriptLib
+local SeismicScanning = {}
+
+SeismicScanning.events = {
+  [defines.events.on_built_entity]       = on_scanner_built,
+  [defines.events.on_robot_built_entity] = on_scanner_built,
+  [defines.events.on_sector_scanned]     = on_sector_scanned,
+}
+
+return SeismicScanning


### PR DESCRIPTION
Proposed change: use core/event-handler for control stage to break down each script mechanic to its own separate module (i.e. lava-pool, seamount, dredging) to improve maintainability.