### PR TITLE
Do not revert bzlead recipe changes when bztin is enabled

### DIFF
--- a/prototypes/recipe-updates.lua
+++ b/prototypes/recipe-updates.lua
@@ -7,18 +7,20 @@ bzutil.set_ingredient("big-electric-pole", "steel-plate", 2)  -- From 5
 bzutil.set_ingredient("substation", "lead-plate", 10)  -- From 2
 bzutil.set_ingredient("substation", "steel-plate", 5)  -- From 10
 
--- Revert bzlead's changes to early game things that need to be built before lead is accessible
-bzutil.replace_ingredient("pipe", "lead-plate", "iron-plate")
-bzutil.remove_ingredient("gun-turret", "lead-plate")
-bzutil.set_ingredient("gun-turret", "iron-plate", 20)
-bzutil.replace_ingredient("firearm-magazine", "lead-plate", "iron-plate")
-bzutil.remove_ingredient("piercing-rounds-magazine", "firearm-magazine")
-bzutil.add_ingredient("piercing-rounds-magazine", "lead-plate", 5)
+if not mods["bztin"] then
+  -- Revert bzlead's changes to early game things that need to be built before lead is accessible
+  bzutil.replace_ingredient("pipe", "lead-plate", "iron-plate")
+  bzutil.remove_ingredient("gun-turret", "lead-plate")
+  bzutil.set_ingredient("gun-turret", "iron-plate", 20)
+  bzutil.replace_ingredient("firearm-magazine", "lead-plate", "iron-plate")
+  bzutil.remove_ingredient("piercing-rounds-magazine", "firearm-magazine")
+  bzutil.add_ingredient("piercing-rounds-magazine", "lead-plate", 5)
 
--- Increase lead costs for overall usage balance
-bzutil.set_ingredient("sulfuric-acid", "lead-plate", 3)  -- From 1
-bzutil.set_ingredient("battery", "lead-plate", 2)  -- From 1
-bzutil.set_ingredient("electric-furnace", "lead-plate", 10)  -- From 4
+  -- Increase lead costs for overall usage balance
+  bzutil.set_ingredient("sulfuric-acid", "lead-plate", 3)  -- From 1
+  bzutil.set_ingredient("battery", "lead-plate", 2)  -- From 1
+  bzutil.set_ingredient("electric-furnace", "lead-plate", 10)  -- From 4
+end
 
 -- Revert bztitanium's changes to hovercrafts
 bzutil.replace_ingredient("hcraft-recipe", "titanium-plate", "steel-plate")


### PR DESCRIPTION
Lead ore patches are moved close to spawn when bztin is present, so it doesn't make sense to revert those recipes in that case.